### PR TITLE
fix(gulp): build task uses babel-preset-es2015

### DIFF
--- a/build/babel-options.js
+++ b/build/babel-options.js
@@ -12,7 +12,7 @@ exports.base = function() {
     comments: false,
     compact: false,
     code: true,
-    presets: [ 'es2015-loose', 'stage-1'],
+    presets: [ 'es2015', 'stage-1'],
     plugins: [
       'syntax-flow',
       'transform-decorators-legacy',


### PR DESCRIPTION
instead of the babel-preset-es2015-loose

https://github.com/SpoonX/swan-example-client/issues/44